### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ OR
 
 ##Use your meta tag data in your template
 
-	- var title       = (typeof meta.TITLE       !== "undefined") ? meta.TITLE       : 'A default title';
-	- var description = (typeof meta.DESCRIPTION !== "undefined") ? meta.DESCRIPTION : 'A default description';
-	- var canonical   = (typeof meta.CANONICAL   !== "undefined") ? meta.CANONICAL   : false;
+	- var title       = (typeof meta !== "undefined") ? meta.TITLE       : 'A default title';
+	- var description = (typeof meta !== "undefined") ? meta.DESCRIPTION : 'A default description';
+	- var canonical   = (typeof meta !== "undefined") ? meta.CANONICAL   : false;
 
 	title #{title}
 	meta(charset="utf-8")


### PR DESCRIPTION
Trying to get "meta.TITLE", "meta.DESCRIPTION" etc. for a URL which is undefined in Redis, express would return a 500 since the "meta" variable itself was undefined.
This cleans up the view code a little bit and fixed the error - URLs still undefined in Redis will now get the default values.
